### PR TITLE
Channel eshtablishment and change of package structure 

### DIFF
--- a/consumer/consumer_relay.go
+++ b/consumer/consumer_relay.go
@@ -18,16 +18,25 @@ type WSConsumerRelay struct {
 
 	// Inbound messages from the clients.
 	// broadcast chan []byte
+	broadcast chan []byte
 
 	// Register requests from the clients.
 	// register chan *Consumer
+	register chan *Consumer
 
 	// Unregister requests from clients.
 	// unregister chan *Consumer
+	unregister chan *Consumer
 }
 
 func NewWSConsumerRelay() *WSConsumerRelay {
-	return &WSConsumerRelay{}
+	return &WSConsumerRelay{
+		topicStore: &messagequeue.Store,
+		clients:    map[*websocket.Conn]bool{},
+		broadcast:  make(chan []byte),
+		register:   make(chan *Consumer),
+		unregister: make(chan *Consumer),
+	}
 }
 
 func (wscr *WSConsumerRelay) Relay() error {

--- a/load/load_distributor.go
+++ b/load/load_distributor.go
@@ -1,4 +1,4 @@
-package replica
+package load
 
 type LoadDistributor struct {
 	PartitionsCount int

--- a/load/load_partition.go
+++ b/load/load_partition.go
@@ -1,4 +1,4 @@
-package replica
+package load
 
 import (
 	consumer "github.com/AdityaMayukhSom/ruskin/consumer"

--- a/load/load_partition_factory.go
+++ b/load/load_partition_factory.go
@@ -1,4 +1,4 @@
-package replica
+package load
 
 import "github.com/AdityaMayukhSom/ruskin/consumer"
 


### PR DESCRIPTION
The Package replica is changed to load because all other packages are named according to the directory structure. New channels are created in the Consumer Relay.